### PR TITLE
working version of external flagsets

### DIFF
--- a/example/external_flagsets/go.mod
+++ b/example/external_flagsets/go.mod
@@ -1,0 +1,10 @@
+module opts_glog_example
+
+go 1.12
+
+replace github.com/jpillora/opts => ../../
+
+require (
+	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+	github.com/jpillora/opts v0.0.0-20160806153215-3f7962811f23
+)

--- a/example/external_flagsets/main.go
+++ b/example/external_flagsets/main.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/golang/glog"
+	"github.com/jpillora/opts"
+)
+
+type root struct {
+}
+type foo struct {
+}
+type man struct {
+}
+type chew struct {
+}
+
+func main() {
+	ro := opts.New(&root{}).
+		// AddFlagSet(flag.CommandLine).
+		AddGoCommandLineFlagSet().
+		Version("asdf").
+		Complete().
+		SetLineWidth(132).
+		AddCommand(opts.New(&foo{}).Name("foo").AddCommand(
+			opts.New(&man{}).Name("man").AddCommand(
+				opts.New(&chew{}).Name("chew"))))
+	po := ro.Parse()
+	_ = po
+	po.RunFatal()
+}
+
+func (rt *root) Run() {
+	fmt.Printf("----\n")
+	flag.CommandLine.VisitAll(func(f *flag.Flag) {
+		fmt.Printf("fxxx %+v\n", f)
+	})
+	glog.Infof("root %v\n", rt)
+}
+
+func (obj *foo) Run() { println("foo") }
+func (obj *man) Run() { println("man") }
+func (obj *chew) Run() {
+	println("\nchew")
+}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/jpillora/opts
 
 go 1.12
 
-require github.com/posener/complete v1.2.1 // indirect
+require github.com/posener/complete v1.2.1

--- a/node.go
+++ b/node.go
@@ -1,6 +1,9 @@
 package opts
 
-import "reflect"
+import (
+	"flag"
+	"reflect"
+)
 
 //item is the structure representing a
 //an opt item
@@ -29,6 +32,8 @@ type node struct {
 	optnames map[string]bool
 	envnames map[string]bool
 	cfgPath  string
+	//external flagset
+	external_flagsets []*flag.FlagSet
 	//subcommands
 	cmd     *node
 	cmdname *reflect.Value

--- a/opts.go
+++ b/opts.go
@@ -1,6 +1,7 @@
 package opts
 
 import (
+	"flag"
 	"reflect"
 )
 
@@ -11,6 +12,8 @@ type Opts interface {
 	ConfigPath(path string) Opts
 	UseEnv() Opts
 	Complete() Opts
+	AddFlagSet(*flag.FlagSet) Opts
+	AddGoCommandLineFlagSet() Opts
 	//documentation
 	Repo(repo string) Opts
 	Author(author string) Opts


### PR DESCRIPTION
Working version of adding external flagsets
eg
```go
opts.New(&root{}).
		AddGoCommandLineFlagSet().
               ...
//or
opts.New(&root{}).
		AddFlagSet(flag.CommandLine).
               ...
```