### PR TITLE
mode=parsedopts & all errors during parsing are either author or cli user errors

### DIFF
--- a/node_build.go
+++ b/node_build.go
@@ -195,6 +195,15 @@ func (o *authorError) Error() string {
 	return o.err
 }
 
+type parseError struct {
+	msg string
+	n   *node
+}
+
+func (o *parseError) Error() string {
+	return o.msg
+}
+
 type exitError struct {
 	msg string
 }

--- a/node_build.go
+++ b/node_build.go
@@ -15,6 +15,19 @@ func (n *node) errorf(format string, args ...interface{}) error {
 	return err
 }
 
+//parseErrorf
+func (n *node) parseErrorf(format string, args ...interface{}) error {
+	err := &parseError{
+		msg: fmt.Sprintf(format, args...),
+		n:   n,
+	}
+	//only store the first error
+	if n.err == nil {
+		n.err = err
+	}
+	return err
+}
+
 //Name sets the name of the program
 func (n *node) Name(name string) Opts {
 	n.name = name

--- a/node_parse.go
+++ b/node_parse.go
@@ -304,21 +304,10 @@ func (n *node) addKVField(kv *kv, fName, help, mode, group string, val reflect.V
 		return n.addInlineCmd(name, help, val)
 	}
 	if mode == "parsedOpts" {
-		// if _, ok := val.Interface().(ParsedOpts); !ok {
-		// 	return n.errorf("not of type opts.ParsedOpts")
-		// }
-		ok := true
-		func() {
-			defer func() {
-				if recover() != nil {
-					ok = false
-				}
-			}()
-			val.Set(reflect.ValueOf(n))
-		}()
-		if !ok {
+		if fmt.Sprintf("%#+v", val) != "opts.ParsedOpts(nil)" {
 			return n.errorf("not of type opts.ParsedOpts")
 		}
+		val.Set(reflect.ValueOf(n))
 		return nil
 	}
 	//from this point, we must have a flag or an arg


### PR DESCRIPTION
@jpillora this represents two separate issues

1. Differentiating between author and user errors. In the case of user errors the help for the subcommand should be printed (hence parseError struct) not the root help.

2. Supporting `mode=parsedOpts`. The error checking on `val.Set` is ugly, but I was sure how to get he short version to work.