### PR TITLE
README: fix typos about unmarshalers

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,9 +136,9 @@ In general an opts _flag-value_ type aims to be any type that can be get and set
 - [`flag.Value`](https://golang.org/pkg/flag/#Value)
 	- *Is an `opts.Setter`*
 - `time.Duration`
-- `encoding.TextMarshaler`
+- `encoding.TextUnmarshaler`
 	- *Includes `time.Time` and `net.IP`*
-- `encoding.BinaryMarshaler`
+- `encoding.BinaryUnmarshaler`
 	- *Includes `url.URL`*
 
 In addition, `flag`s and `arg`s can also be a slice of any _flag-value_ type. Slices allow multiple flags/args. For example, a struct field flag `Foo []int` could be set with `--foo 1 --foo 2`, and would result in `[]int{1,2}`.


### PR DESCRIPTION
Just a few typos.

By the way, thanks for this framework that recognizes the value of the `flag.Value` interface. I have myself accumulated a set of helpers to work with `flag.Value`: [`github.com/dolmen-go/flagx`](https://godoc.org/github.com/dolmen-go/flagx).