### PR TITLE
Proto n fieldconfig

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/jpillora/opts
 
 go 1.12
 
-require github.com/posener/complete v1.2.2-0.20190308074557-af07aa5181b3
+require (
+	github.com/posener/complete v1.2.2-0.20190308074557-af07aa5181b3
+	gopkg.in/yaml.v2 v2.2.2
+)

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/jpillora/opts
 go 1.12
 
 require (
+	github.com/golang/protobuf v1.3.2
 	github.com/posener/complete v1.2.2-0.20190308074557-af07aa5181b3
 	gopkg.in/yaml.v2 v2.2.2
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
+github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=

--- a/go.sum
+++ b/go.sum
@@ -4,3 +4,7 @@ github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uP
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/posener/complete v1.2.2-0.20190308074557-af07aa5181b3 h1:GqpA1/5oN1NgsxoSA4RH0YWTaqvUlQNeOpHXD/JRbOQ=
 github.com/posener/complete v1.2.2-0.20190308074557-af07aa5181b3/go.mod h1:6gapUrK/U1TAN7ciCoNRIdVC5sbdBTUh1DKN0g6uH7E=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/item.go
+++ b/item.go
@@ -84,11 +84,15 @@ func newItem(val reflect.Value) (*item, error) {
 	}
 	//type checks
 	t := i.elemType()
-	// if t.Kind() == reflect.Ptr {
-	// 	return nil, fmt.Errorf("slice elem (%s) cannot be a pointer", t.Kind())
-	// } else if i.slice && t.Kind() == reflect.Bool {
-	// 	return nil, fmt.Errorf("slice of bools not supported")
-	// }
+	// vv issues for Proto generated struct
+	if t.Kind() == reflect.Ptr {
+		// supported = true
+		return nil, fmt.Errorf("slice elem (%s) cannot be a pointer", t.Kind())
+	} else if i.slice && t.Kind() == reflect.Bool {
+		// supported = true
+		return nil, fmt.Errorf("slice of bools not supported")
+	}
+	// ^^ issues for Proto generated struct
 	switch t.Kind() {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
 		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
@@ -103,9 +107,9 @@ func newItem(val reflect.Value) (*item, error) {
 		i.noarg = true
 	}
 	_ = supported
-	// if !supported {
-	// 	return nil, fmt.Errorf("field type not supported: %s", t.Kind())
-	// }
+	if !supported {
+		return nil, fmt.Errorf("field type not supported: %s", t.Kind())
+	}
 	return i, nil
 }
 

--- a/item.go
+++ b/item.go
@@ -84,11 +84,11 @@ func newItem(val reflect.Value) (*item, error) {
 	}
 	//type checks
 	t := i.elemType()
-	if t.Kind() == reflect.Ptr {
-		return nil, fmt.Errorf("slice elem (%s) cannot be a pointer", t.Kind())
-	} else if i.slice && t.Kind() == reflect.Bool {
-		return nil, fmt.Errorf("slice of bools not supported")
-	}
+	// if t.Kind() == reflect.Ptr {
+	// 	return nil, fmt.Errorf("slice elem (%s) cannot be a pointer", t.Kind())
+	// } else if i.slice && t.Kind() == reflect.Bool {
+	// 	return nil, fmt.Errorf("slice of bools not supported")
+	// }
 	switch t.Kind() {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
 		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
@@ -102,9 +102,10 @@ func newItem(val reflect.Value) (*item, error) {
 	} else if t.Kind() == reflect.Bool {
 		i.noarg = true
 	}
-	if !supported {
-		return nil, fmt.Errorf("field type not supported: %s", t.Kind())
-	}
+	_ = supported
+	// if !supported {
+	// 	return nil, fmt.Errorf("field type not supported: %s", t.Kind())
+	// }
 	return i, nil
 }
 

--- a/node.go
+++ b/node.go
@@ -34,13 +34,19 @@ type node struct {
 	padWidth                       int
 	//pretend these are in the user struct :)
 	internalOpts struct {
-		Help       bool
-		Version    bool
-		Install    bool
-		Uninstall  bool
-		ConfigPath string
+		Help         bool
+		Version      bool
+		Install      bool
+		Uninstall    bool
+		ConfigPath   string
+		FieldConfigs []fieldConfig
 	}
 	complete bool
+}
+
+type fieldConfig struct {
+	path string
+	obj  interface{}
 }
 
 func newNode(val reflect.Value) *node {

--- a/node_build.go
+++ b/node_build.go
@@ -70,6 +70,11 @@ func (n *node) SetLineWidth(l int) Opts {
 	return n
 }
 
+func (n *node) FieldConfigPath(path string, obj interface{}) Opts {
+	n.internalOpts.FieldConfigs = append(n.internalOpts.FieldConfigs, fieldConfig{path, obj})
+	return n
+}
+
 func (n *node) ConfigPath(path string) Opts {
 	n.internalOpts.ConfigPath = path
 	return n

--- a/node_parse.go
+++ b/node_parse.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/golang/protobuf/proto"
 	"gopkg.in/yaml.v2"
 )
 
@@ -146,29 +147,15 @@ func (n *node) parse(args []string) error {
 		}
 	}
 	//second round, unmarshal directly into the struct, overwrites envs and flags
+	for _, fg := range n.internalOpts.FieldConfigs {
+		if err := stuffConfig(fg.path, fg.obj); err != nil {
+			return err
+		}
+	}
 	if c := n.internalOpts.ConfigPath; c != "" {
-		if abs, err := filepath.Abs(os.ExpandEnv(c)); err != nil {
-			// problem with file
-		} else {
-			if b, err := ioutil.ReadFile(abs); err != nil {
-				// problem with file
-			} else {
-				v := n.val.Addr().Interface() //*struct
-				switch {
-				case strings.HasSuffix(c, ".yml") || strings.HasSuffix(c, ".yaml"):
-					err = yaml.Unmarshal(b, v)
-					if err != nil {
-						return fmt.Errorf("Invalid config file: %s err: %s", c, err)
-					}
-				case strings.HasSuffix(c, ".json"):
-					err = json.Unmarshal(b, v)
-					if err != nil {
-						return fmt.Errorf("Invalid config file: %s err: %s", c, err)
-					}
-				default:
-					return fmt.Errorf("Invalid config file, only .yaml, .yml and .json accepted : %s", c)
-				}
-			}
+		v := n.val.Addr().Interface() //*struct
+		if err := stuffConfig(c, v); err != nil {
+			return err
 		}
 	}
 	//get remaining args after extracting flags
@@ -224,6 +211,40 @@ func (n *node) parse(args []string) error {
 	//where --pong 7 is ignored
 	if len(remaining) != 0 {
 		return fmt.Errorf("Unexpected arguments: %s", strings.Join(remaining, " "))
+	}
+	return nil
+}
+
+func stuffConfig(path string, obj interface{}) error {
+	//second round, unmarshal directly into the struct, overwrites envs and flags
+	if abs, err := filepath.Abs(os.ExpandEnv(path)); err != nil {
+		// problem with file
+		return err
+	} else {
+		if b, err := ioutil.ReadFile(abs); err != nil {
+			// problem with file
+			return err
+		} else {
+			switch {
+			case strings.HasSuffix(path, ".yml") || strings.HasSuffix(path, ".yaml"):
+				err = yaml.Unmarshal(b, obj)
+				if err != nil {
+					return fmt.Errorf("Invalid config file: %s err: %s", path, err)
+				}
+			case strings.HasSuffix(path, ".json"):
+				err = json.Unmarshal(b, obj)
+				if err != nil {
+					return fmt.Errorf("Invalid config file: %s err: %s", path, err)
+				}
+			case strings.HasSuffix(path, ".ptron"):
+				err := proto.UnmarshalText(string(b), obj.(proto.Message))
+				if err != nil {
+					return fmt.Errorf("Invalid config file: %s err: %s", path, err)
+				}
+			default:
+				return fmt.Errorf("Invalid config file, only .yaml, .yml and .json accepted : %s", path)
+			}
+		}
 	}
 	return nil
 }

--- a/opts.go
+++ b/opts.go
@@ -20,6 +20,7 @@ type Opts interface {
 	//global paths like /etc/my-prog.json. For a user-specified path. Use the
 	//UserConfigPath method.
 	ConfigPath(path string) Opts
+	FieldConfigPath(path string, obj interface{}) Opts
 	//UserConfigPath is the same as ConfigPath however an extra flag (--config-path)
 	//is added to this Opts instance to give the user control of the filepath.
 	//Configuration unmarshalling occurs after flag parsing.


### PR DESCRIPTION
@jpillora 

Looking for your feedback;
1. The added method `FieldConfigPath` might be a general replacement for `ConfigPath`. It's more flexible and encompasses the existing functionality.
1. How can protoc generated stuct get supported. Note not an issue in the example below.

``` go
type Config struct {
	cfg       *config.Config
	OutputDir string `opts:"mode=arg" help:"output directory eg ."`
}

func main() {
	cfg := &Config{cfg: &config.Config{}}
	opts.New(&root{}).
		Name("godna").
		EmbedGlobalFlagSet().
		Complete().
		Version(version).
		AddCommand(opts.New(cfg).Name("regen").
			FieldConfigPath("./.dna-cfg.ptron", cfg.cfg)). //, "godna.Config")).
		Parse().
		RunFatal()
}
```