### PR TITLE
Return matching ParseOpts

### DIFF
--- a/opts.go
+++ b/opts.go
@@ -88,10 +88,10 @@ type ParsedOpts interface {
 	//Help returns the final help text
 	Help() string
 	//IsRunnable returns whether the matched command has a Run method
-	IsRunnable() bool
+	IsRunnable() (ParsedOpts, bool)
 	//Run assumes the matched command is runnable and executes its Run method.
 	//The target Run method must be 'Run() error' or 'Run()'
-	Run() error
+	Run() (ParsedOpts, error)
 	//RunFatal assumes the matched command is runnable and executes its Run method.
 	//However, any error will be printed, followed by an exit(1).
 	RunFatal()


### PR DESCRIPTION
Returns the matched sub-command.
This enables printing the help of the sub-command.
eg
``` golang
func main() {
	c := cmd{}
	//default name for the root command (package main) is the binary name
	parsedOpts, err := opts.New(&c).
		AddCommand(foo.New()).
		Parse().
		Run()
	if err != nil {
		fmt.Fprintln(os.Stderr, parsedOpts.Help())
		fmt.Fprintf(os.Stderr, "Error:\n\t%s\n", err)
	}

}
```

This is a breaking change, however it is unlike to cause much of an issue.
eg none of the opt-example broke.
see https://github.com/jpillora/opts-examples/compare/master...millergarym:return-matching?expand=1