### PR TITLE
Addition of Selected method to ParsedOpts interface

### DIFF
--- a/node_commands.go
+++ b/node_commands.go
@@ -46,14 +46,20 @@ func (n *node) matchedCommand() *node {
 
 //IsRunnable
 func (n *node) IsRunnable() bool {
-	ok, _ := n.run(true)
+	_, ok, _ := n.run(true)
 	return ok
 }
 
 //Run the parsed configuration
 func (n *node) Run() error {
-	_, err := n.run(false)
+	_, _, err := n.run(false)
 	return err
+}
+
+//Selected returns the subcommand picked when parsing the command line
+func (n *node) Selected() ParsedOpts {
+	m := n.matchedCommand()
+	return m
 }
 
 type runner1 interface {
@@ -64,27 +70,27 @@ type runner2 interface {
 	Run()
 }
 
-func (n *node) run(test bool) (bool, error) {
+func (n *node) run(test bool) (ParsedOpts, bool, error) {
 	m := n.matchedCommand()
 	v := m.val.Addr().Interface()
 	r1, ok1 := v.(runner1)
 	r2, ok2 := v.(runner2)
 	if test {
-		return ok1 || ok2, nil
+		return m, ok1 || ok2, nil
 	}
 	if ok1 {
-		return true, r1.Run()
+		return m, true, r1.Run()
 	}
 	if ok2 {
 		r2.Run()
-		return true, nil
+		return m, true, nil
 	}
 	if len(m.cmds) > 0 {
 		//if matched command has no run,
 		//but has commands, show help instead
-		return false, exitError(m.Help())
+		return m, false, fmt.Errorf("sub command '%s' is not runnable", m.name)
 	}
-	return false, fmt.Errorf("command '%s' is not runnable", m.name)
+	return m, false, fmt.Errorf("command '%s' is not runnable", m.name)
 }
 
 //Run the parsed configuration

--- a/opts.go
+++ b/opts.go
@@ -95,6 +95,8 @@ type ParsedOpts interface {
 	//RunFatal assumes the matched command is runnable and executes its Run method.
 	//However, any error will be printed, followed by an exit(1).
 	RunFatal()
+	//Selected returns the subcommand picked when parsing the command line
+	Selected() ParsedOpts
 }
 
 //New creates a new Opts instance using the given configuration


### PR DESCRIPTION
Unlike pervious PR this is backward compatible.

This allows for help for the specific subcommand help to be printed.
eg
``` golang
	cli := cliBldr.Parse()
	err := cli.Run()
	if err != nil {
		fmt.Fprintf(os.Stderr, "error: %v\n%s\n", err, cli.Selected().Help())
		os.Exit(1)
	}
```