### PR TITLE
check if complete error type to prevent panic

### DIFF
--- a/node_complete.go
+++ b/node_complete.go
@@ -39,14 +39,18 @@ func (n *node) manageCompletion(uninstall bool) error {
 		fn = install.Uninstall
 	}
 	if err := fn(n.name); err != nil {
-		w := err.(interface{ WrappedErrors() []error })
-		for _, w := range w.WrappedErrors() {
-			msg += strings.TrimPrefix(fmt.Sprintf("%s\n", w), "does ")
+		w, ok := err.(interface{ WrappedErrors() []error })
+		if ok {
+			for _, w := range w.WrappedErrors() {
+				msg += strings.TrimPrefix(fmt.Sprintf("%s\n", w), "does ")
+			}
+		} else {
+			msg = fmt.Sprintf("%v\n", err)
 		}
 	} else if uninstall {
-		msg = "Uninstalled"
+		msg = "Uninstalled\n"
 	} else {
-		msg = "Installed"
+		msg = "Installed\n"
 	}
 	return exitError(msg) //always exit
 }

--- a/node_parse.go
+++ b/node_parse.go
@@ -144,7 +144,7 @@ func (n *node) parse(args []string) error {
 	} else if n.internalOpts.Uninstall {
 		return n.manageCompletion(true)
 	}
-	//first round of defaults, applying env variables where necesseary
+	//first round of defaults, applying env variables where necessary
 	for _, item := range n.flags() {
 		k := item.envName
 		if item.set() || k == "" {


### PR DESCRIPTION
If no profile file is found (`.zshrc`, `.profile`, `.bash_profile` etc) a simple error, not a wrapped error is return.
This fixes stop a panic in this case.