### PR TITLE
Adding to Opts API to make adding sub-command more friendly

### DIFF
--- a/node_build.go
+++ b/node_build.go
@@ -142,6 +142,10 @@ func (n *node) Call(fn func(o Opts)) Opts {
 	return n
 }
 
+func (n *node) End() Opts {
+	return n
+}
+
 func (n *node) flagGroup(name string) *itemGroup {
 	//NOTE: the default group is the empty string
 	//get existing group

--- a/node_commands.go
+++ b/node_commands.go
@@ -4,7 +4,64 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"reflect"
+	"strings"
 )
+
+type subCmdHolderI interface {
+	isSubCmdHolder()
+}
+
+type subCmdHolder struct{}
+
+func (subCmdHolder) isSubCmdHolder() {}
+
+//NewStruct adds multiple Opts instances under the sub-command name.
+//The name can be a slash separated path.
+func NewStruct(path string, subs ...Opts) Opts {
+	names := strings.Split(path, "/")
+	fn := func(name string) *node {
+		cmd := newNode(reflect.ValueOf(&subCmdHolder{}))
+		cmd.name = names[0]
+		return cmd
+	}
+	return addStruct(fn, path, subs...)
+}
+
+func (n *node) AddStruct(path string, subs ...Opts) Opts {
+	names := strings.Split(path, "/")
+	fn := func(name string) *node {
+		return n.newStruct(names[0])
+	}
+	return addStruct(fn, path, subs...)
+}
+
+func addStruct(fn func(string) *node, name string, subs ...Opts) Opts {
+	names := strings.Split(name, "/")
+	cmd := fn(names[0])
+	cmd0 := cmd
+	for _, name0 := range names[1:] {
+		cmd1 := cmd0.newStruct(name0)
+		cmd0.AddCommand(cmd1)
+		cmd0 = cmd1
+	}
+	for _, sub := range subs {
+		cmd0.AddCommand(sub)
+	}
+	return cmd
+}
+
+func (n *node) newStruct(name string) *node {
+	if sub, exists := n.cmds[name]; exists {
+		return sub
+	} else {
+		sub := newNode(reflect.ValueOf(&subCmdHolder{}))
+		sub.name = name
+		sub.parent = n
+		n.cmds[name] = sub
+		return sub
+	}
+}
 
 func (n *node) AddCommand(cmd Opts) Opts {
 	sub, ok := cmd.(*node)
@@ -28,9 +85,19 @@ func (n *node) AddCommand(cmd Opts) Opts {
 		n.errorf("cannot add command, please set a Name()")
 		return n
 	}
-	if _, exists := n.cmds[sub.name]; exists {
-		n.errorf("cannot add command, '%s' already exists", sub.name)
-		return n
+	if sub0, exists := n.cmds[sub.name]; exists {
+		if _, ok1 := sub0.item.val.Interface().(subCmdHolderI); ok1 {
+			if _, ok2 := sub.item.val.Interface().(subCmdHolderI); !ok2 {
+				// replace sub cmd holding with provided sub cmd
+				for k, v := range sub0.cmds {
+					sub.cmds[k] = v
+					v.parent = sub
+				}
+			}
+		} else {
+			n.errorf("cannot add command, '%s' already exists", sub.name)
+			return n
+		}
 	}
 	sub.parent = n
 	n.cmds[sub.name] = sub

--- a/opts.go
+++ b/opts.go
@@ -70,9 +70,14 @@ type Opts interface {
 	//SetLineWidth alters the maximum number of characters in a
 	//line (excluding padding). By default, line width is 96.
 	SetLineWidth(width int) Opts
-
 	//AddCommand adds another Opts instance as a subcommand.
 	AddCommand(Opts) Opts
+	//AddStruct adds multiple Opts instances under the sub-command name.
+	//The name can be a slash separated path.
+	AddStruct(name string, subs ...Opts) Opts
+	//End is a noop, it is simply to there enable nice layout when using the api.
+	End() Opts
+
 	//Parse calls ParseArgs(os.Args).
 	Parse() ParsedOpts
 	//ParseArgs parses the given strings and stores the results


### PR DESCRIPTION
Allows for the following
``` go
var (
	rflg    = &types.Root{}
	cliBldr = opts.New(rflg).
		Name("wx").
		EmbedGlobalFlagSet().
		Complete()
)

func main() {
	cli := cliBldr.Parse()
	err := cli.Run()
	if err != nil {
		fmt.Fprintf(os.Stderr, "%[2]s\nError: %[1]v\n\n", err, cli.Selected().Help())
		os.Exit(1)
	}
}

func init() {
	// using End
	cliBldr.AddCommand(opts.New(&struct{}{}).Name("cli").
		AddCommand(opts.New(rename.NewRename(rflg)).Name("rename")).
		AddCommand(opts.New(newsubcmd.New(rflg)).Name("new_sub_command")).
		End())

	// using AddStruct and NewStruct
	cliBldr.AddStruct("a",
		opts.NewStruct("b",
			opts.NewStruct("c",
				opts.NewStruct("d",
					opts.New(xxx.NewXxx(rflg)),
					opts.New(xxy.NewXxy(rflg)).Name("3456789"),
				),
			),
		),
	)

	// Adding new sub-command to existing cmd structure
	cliBldr.AddStruct("a/b/c/d",
		opts.New(xxx.NewXxx(rflg)).Name("abcsdaf"),
	)

	// Replace a sub-command struct holding position with a runnable sub-command
	cliBldr.AddCommand(opts.New(&versionCmd{}).Name("a"))

	// Adding new sub-command to existing cmd structure
	cliBldr.AddStruct("a/bb/cc/dd",
		opts.New(xxy.NewXxy(rflg)),
	)
}
```