### PR TITLE
added children to ParsedOpts api

### DIFF
--- a/node_commands.go
+++ b/node_commands.go
@@ -44,6 +44,14 @@ func (n *node) matchedCommand() *node {
 	return n
 }
 
+func (n *node) Children() map[string]Opts {
+	result := make(map[string]Opts)
+	for name, cmd := range n.cmds {
+		result[name] = cmd
+	}
+	return result
+}
+
 //IsRunnable
 func (n *node) IsRunnable() bool {
 	_, ok, _ := n.run(true)

--- a/opts.go
+++ b/opts.go
@@ -97,6 +97,8 @@ type ParsedOpts interface {
 	RunFatal()
 	//Selected returns the subcommand picked when parsing the command line
 	Selected() ParsedOpts
+	//Children returns the subcommands of this command
+	Children() map[string]Opts
 }
 
 //New creates a new Opts instance using the given configuration


### PR DESCRIPTION
This allow clients of the opts library to iterator through the subcommands structure.
Useful for generating documentation for all subcommands.