### PR TITLE
node_parse: impelement default argument fallback

### DIFF
--- a/node_parse.go
+++ b/node_parse.go
@@ -147,7 +147,13 @@ func (n *node) parse(args []string) error {
 	//first round of defaults, applying env variables where necessary
 	for _, item := range n.flags() {
 		k := item.envName
-		if item.set() || k == "" {
+		if item.set() {
+			continue
+		}
+		if k == "" {
+			if item.defstr != "" {
+				item.Set(item.defstr)
+			}
 			continue
 		}
 		v := os.Getenv(k)

--- a/opts_test.go
+++ b/opts_test.go
@@ -594,6 +594,31 @@ func TestCustomFlags(t *testing.T) {
 	}
 }
 
+func TestDefault(t *testing.T) {
+	//config
+	type Config struct {
+		Foo string `opts:"default=bar"`
+		Bar int    `opts:"default=1337"`
+	}
+	c := &Config{}
+	//flag example parse
+	New(c).Name("docargs").ParseArgs([]string{"/bin/prog"})
+	if c.Foo != "bar" {
+		t.Fatalf("incorrect foo: %v", c.Foo)
+	}
+	if c.Bar != 1337 {
+		t.Fatalf("incorrect bar: %v", c.Bar)
+	}
+
+	New(c).Name("docargs").ParseArgs([]string{"/bin/prog", "--foo", "qux"})
+	if c.Foo != "qux" {
+		t.Fatalf("incorrect foo: %v", c.Foo)
+	}
+	if c.Bar != 1337 {
+		t.Fatalf("incorrect bar: %v", c.Bar)
+	}
+}
+
 var spaces = regexp.MustCompile(`\ `)
 var newlines = regexp.MustCompile(`\n`)
 


### PR DESCRIPTION
The parser was previously not setting values specified in the `default` struct tag in the absence of a supplied argument. This commit changes the behaviour such that the provided default will be used in place of an empty value when a flag is not set.

Fixes #36.